### PR TITLE
Align first gate by specifying a prefWidth for the title label

### DIFF
--- a/src/main/java/com/gluonhq/strange/ui/QubitFlow.java
+++ b/src/main/java/com/gluonhq/strange/ui/QubitFlow.java
@@ -92,6 +92,7 @@ public class QubitFlow extends Region {
 
         gateRow.getStyleClass().add("gate-row");
         title.getStyleClass().add("title");
+        title.setPrefWidth(85);
 
         line.endXProperty().bind(widthProperty());
         line.getStyleClass().add("wire");


### PR DESCRIPTION
This fixed #35 