### PR TITLE
First symbol in CNot is the dot.

### DIFF
--- a/src/main/java/com/gluonhq/strange/ui/GateSymbol.java
+++ b/src/main/java/com/gluonhq/strange/ui/GateSymbol.java
@@ -84,7 +84,8 @@ public class GateSymbol extends Label {
         this.movable = movable;
         if (!(gate instanceof Identity)) {
             if (gate instanceof Cnot) {
-                if (idx > 0) {
+                if (idx == 0) {
+                    // first symbol of Cnot is dot
                     Group g = new Group();
                     Circle c = new Circle(0,0,5, Color.DARKGREY);
                     g.getChildren().add(c);


### PR DESCRIPTION
This fixes #40

The bug appeared after the fix in Strange for modified main qubit index values:
https://github.com/gluonhq/strange/commit/86891450536570d13b18ce8ffca35d2bfaf596bb